### PR TITLE
chore(ci): Update to Python 3.14 and Django 6.0 stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
 
       - name: Install dependencies
@@ -36,10 +36,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
 
       - name: Install dependencies
@@ -58,10 +58,10 @@ jobs:
     name: Security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
 
       - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Upload Coverage Results"
         if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Bandit Security Report
           path: report.json
@@ -93,18 +93,13 @@ jobs:
       matrix:
         include:
           # Fast feedback with SQLite
-          - python-version: "3.13"
-            django-version: "~=5.2"
+          - python-version: "3.14"
+            django-version: "~=6.0"
             db: sqlite
           # Production configuration
-          - python-version: "3.13"
-            django-version: "~=5.2"
-            db: mariadb
-          # Future-proofing (experimental - allowed to fail)
           - python-version: "3.14"
             django-version: "~=6.0"
             db: mariadb
-            experimental: true
 
     services:
       mariadb:
@@ -126,9 +121,9 @@ jobs:
           mysql --host 127.0.0.1 --port 3306 -uroot -ppassword -e "SHOW DATABASES" 2>&1 > /dev/null
           mysql --host 127.0.0.1 --port 3306 -uroot -ppassword -V
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -146,7 +141,7 @@ jobs:
           DB_TYPE: ${{ matrix.db }}
         run: export PYTHONPATH=`pwd` && coverage run
       - name: "Upload Coverage Results for PY:${{ matrix.python-version }} DB:${{ matrix.db}} DJ:${{ matrix.django-version }}"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           include-hidden-files: true
           if-no-files-found: warn
@@ -163,17 +158,17 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |
           pip install .
           pip install .[test]
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: .
 
@@ -184,7 +179,7 @@ jobs:
             coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6
         with:
           directory: .
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       bump_version: ${{ steps.release.outputs.bump_version }}
       bump_sha: ${{ steps.release.outputs.bump_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
           fetch-depth: 0
@@ -75,10 +75,10 @@ jobs:
         run: |
           echo "⚠️ Release skipped - commit did not meet release criteria"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: steps.verify.outputs.should_release == 'true'
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         if: steps.verify.outputs.should_release == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
@@ -30,7 +29,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "django>=5.2",
+    "django>=6.0",
     "djangorestframework",
 ]
 


### PR DESCRIPTION
## Summary
- Update all workflows to Python 3.14
- Update GitHub Actions to latest versions (checkout@v6, setup-python@v6, upload-artifact@v7, download-artifact@v8)
- Django 6.0 is now stable (not experimental)

## Test plan
- [ ] CI passes with Python 3.14
- [ ] All tests pass with Django 6.0

Generated with [Claude Code](https://claude.ai/code)