### PR TITLE
chore(ci): pin ruff rule set and test against Django 6.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,13 +92,22 @@ jobs:
       max-parallel: 3
       matrix:
         include:
+          # Pin the SERIES, not 6.x: "~=6.0" means >=6.0,<7.0, so the matrix silently rolls
+          # onto each new Django minor. "~=6.0.0" means >=6.0.0,<6.1.0 — new minors are a
+          # deliberate matrix addition.
           # Fast feedback with SQLite
           - python-version: "3.14"
-            django-version: "~=6.0"
+            django-version: "~=6.0.0"
             db: sqlite
           # Production configuration
           - python-version: "3.14"
-            django-version: "~=6.0"
+            django-version: "~=6.0.0"
+            db: mariadb
+          - python-version: "3.14"
+            django-version: "~=6.1.0"
+            db: sqlite
+          - python-version: "3.14"
+            django-version: "~=6.1.0"
             db: mariadb
 
     services:

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Configure swappable models in your settings (optional):
 
 ```python
 # Use default models
-INPUT_COLLECTEDINPUT_MODEL = 'django_input_collection.CollectedInput'
-INPUT_BOUNDSUGGESTEDRESPONSE_MODEL = 'django_input_collection.BoundSuggestedResponse'
+INPUT_COLLECTEDINPUT_MODEL = "django_input_collection.CollectedInput"
+INPUT_BOUNDSUGGESTEDRESPONSE_MODEL = "django_input_collection.BoundSuggestedResponse"
 ```
 
 ## Core Concepts
@@ -138,6 +138,7 @@ Use the provided mixins to add checklist endpoints to your ViewSets:
 ```python
 from rest_framework.viewsets import ModelViewSet
 from django_input_collection.schema.mixins import ChecklistSchemaMixin, ChecklistConsumerMixin
+
 
 class MyViewSet(ChecklistSchemaMixin, ChecklistConsumerMixin, ModelViewSet):
     def get_collection_request(self, obj):

--- a/django_input_collection/schema/README.md
+++ b/django_input_collection/schema/README.md
@@ -302,8 +302,9 @@ from django_input_collection.schema import (
     register_condition_validator,
 )
 
+
 # Register import resolver (schema -> database)
-@register_condition_resolver('simulation')
+@register_condition_resolver("simulation")
 def resolve_simulation(source: str, values: list | None) -> str | None:
     """Return data_getter string or None if unresolved."""
     registry_entry = SimulationConditionRegistry.get_by_slug(source)
@@ -311,14 +312,16 @@ def resolve_simulation(source: str, values: list | None) -> str | None:
         return f"simulation:{registry_entry.resolver_path}"
     return None
 
+
 # Register export resolver (database -> schema)
-@register_condition_resolver('simulation', direction='export')
+@register_condition_resolver("simulation", direction="export")
 def export_simulation(path: str) -> str | None:
     """Return slug from resolver path, or None."""
     return resolver_to_slug_cache.get(path)
 
+
 # Register validator for serializer validation
-@register_condition_validator('simulation')
+@register_condition_validator("simulation")
 def validate_simulation(source: str, values: list) -> tuple[bool, str | None]:
     """Validate condition source and values. Returns (is_valid, error_message)."""
     registry_entry = SimulationConditionRegistry.get_by_slug(source)
@@ -334,6 +337,7 @@ Applications can register a handler for response flags (comment_required, photo_
 ```python
 from django_input_collection.schema import register_bound_response_handler
 
+
 @register_bound_response_handler()
 class AxisBoundResponseHandler:
     @staticmethod
@@ -342,10 +346,10 @@ class AxisBoundResponseHandler:
         AxisBoundSuggestedResponse.objects.create(
             collection_instrument=instrument,
             suggested_response=suggested_response,
-            comment_required=flags.get('comment_required', False),
-            photo_required=flags.get('photo_required', False),
-            document_required=flags.get('document_required', False),
-            is_considered_failure=flags.get('is_considered_failure', False),
+            comment_required=flags.get("comment_required", False),
+            photo_required=flags.get("photo_required", False),
+            document_required=flags.get("document_required", False),
+            is_considered_failure=flags.get("is_considered_failure", False),
         )
 
     @staticmethod
@@ -355,13 +359,13 @@ class AxisBoundResponseHandler:
         for bound in instrument.bound_suggested_responses.all():
             response_flags = {}
             if bound.comment_required:
-                response_flags['comment_required'] = True
+                response_flags["comment_required"] = True
             if bound.photo_required:
-                response_flags['photo_required'] = True
+                response_flags["photo_required"] = True
             if bound.document_required:
-                response_flags['document_required'] = True
+                response_flags["document_required"] = True
             if bound.is_considered_failure:
-                response_flags['is_considered_failure'] = True
+                response_flags["is_considered_failure"] = True
             if response_flags:
                 flags[bound.suggested_response.data] = response_flags
         return flags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
@@ -101,6 +102,9 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
+# Pin the rule set: ruff 0.16 broadened its implicit default well beyond E/F. Opt into
+# wider rules deliberately, not via a ruff upgrade.
+select = ["E4", "E7", "E9", "F"]
 ignore = ["F401", "E402"]
 fixable = ["ALL"]
 unfixable = []


### PR DESCRIPTION
## Summary

Housekeeping only — no library behaviour changes.

**1. Pin the ruff rule set.** ruff 0.16 broadened its implicit default well beyond `E`/`F`. Since this repo doesn't pin `select`, an unpinned ruff turns the Lint job red with findings unrelated to any change here (`RUF012`, `I001`, `UP0xx`, `SIM1xx`, …). Pinning `select = ["E4","E7","E9","F"]` restores the pre-0.16 set. Adopting the wider rules should be its own deliberate PR.

This is not hypothetical: `tensor-analytics` and `tensor-registration` are already red on master from exactly this.

**2. Run ruff 0.16's formatter.** 0.16 formats python blocks inside markdown, so a few README/docs files change. No `.py` files affected.

**3. Test against Django 6.1**, and pin the existing matrix entries to the 6.0 *series*. `~=6.0` means `>=6.0,<7.0`, so the matrix had already silently rolled onto 6.1 without anyone deciding that — new minors should be a deliberate matrix change. (`simulation` already does this and carries a comment explaining why.) Classifier updated to match.

## Context

Found while bumping Axis to Django 6.1. This package's code needed **no** changes for 6.1 — its `django>=` requirement is open-ended and nothing in it touches the APIs 6.1 changed. This PR is about making CI actually prove that.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check .` clean
- [ ] CI green on both Django 6.0 and 6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)